### PR TITLE
pypy and python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ parts
 develop-eggs/
 eggs/
 *.egg-info/
+.coverage
+coverage.xml
+.tox
+nosetests.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
     - pypy
     - pypy3
 install:
+    - pip install -e .
     - pip install nose
 script:
     - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ python:
     - pypy
     - pypy3
 install:
-    - python bootstrap.py
-    - bin/buildout
+    - pip install nose
 script:
-    - bin/test -v1
+    - nosetests
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: python
 sudo: false
 python:
+    - 2.6
     - 2.7
+    - 3.2
+    - 3.3
+    - 3.4
+    - pypy
+    - pypy3
 install:
     - python bootstrap.py
     - bin/buildout

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,13 @@
 Changelog
 =========
 
-2.13.1 (unreleased)
--------------------
+3.0 (unreleased)
+----------------
 
+- Add compatibility with Pypy and Python 3.
+
+- Arguments to the Unauthorized exception are assumed to be utf8-encoded
+  if they are bytes.
 
 2.13.0 (2010-06-05)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup, find_packages
 
 setup(name='zExceptions',
-      version = '2.13.1dev',
+      version = '3.0.dev0',
       url='http://pypi.python.org/pypi/zExceptions',
       license='ZPL 2.1',
       description="zExceptions contains common exceptions used in Zope2.",

--- a/setup.py
+++ b/setup.py
@@ -14,24 +14,40 @@
 
 from setuptools import setup, find_packages
 
-setup(name='zExceptions',
-      version = '3.0.dev0',
-      url='http://pypi.python.org/pypi/zExceptions',
-      license='ZPL 2.1',
-      description="zExceptions contains common exceptions used in Zope2.",
-      author='Zope Foundation and Contributors',
-      author_email='zope-dev@zope.org',
-      long_description=open('README.txt').read() + '\n' +
-                       open('CHANGES.txt').read(),
-
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      install_requires=[
+setup(
+    name='zExceptions',
+    version='3.0.dev0',
+    url='http://pypi.python.org/pypi/zExceptions',
+    license='ZPL 2.1',
+    description="zExceptions contains common exceptions used in Zope2.",
+    author='Zope Foundation and Contributors',
+    author_email='zope-dev@zope.org',
+    long_description=open('README.txt').read() + '\n' + open('CHANGES.txt').read(),
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    install_requires=[
         'setuptools',
         'zope.interface',
         'zope.publisher',
         'zope.security',
-      ],
-      include_package_data=True,
-      zip_safe=False,
-      )
+    ],
+    classifiers=[
+        "Development Status :: 6 - Mature",
+        "Environment :: Web Environment",
+        "Framework :: Zope2",
+        "License :: OSI Approved :: Zope Public License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.2",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+    ],
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/src/zExceptions/ExceptionFormatter.py
+++ b/src/zExceptions/ExceptionFormatter.py
@@ -177,7 +177,7 @@ class TextExceptionFormatter:
 
     def formatException(self, etype, value, tb, limit=None):
         # The next line provides a way to detect recursion.
-        __exception_formatter__ = 1
+        __exception_formatter__ = 1  # noqa
         result = [self.getPrefix() + '\n']
         if limit is None:
             limit = self.getLimit()

--- a/src/zExceptions/TracebackSupplement.py
+++ b/src/zExceptions/TracebackSupplement.py
@@ -1,8 +1,8 @@
 # Stock __traceback_supplement__ implementations
-
 class PathTracebackSupplement:
     """Implementation of ITracebackSupplement"""
     pp = None
+
     def __init__(self, object):
         self.object = object
         if hasattr(object, 'getPhysicalPath'):

--- a/src/zExceptions/__init__.py
+++ b/src/zExceptions/__init__.py
@@ -24,23 +24,9 @@ from zope.publisher.interfaces import INotFound
 from zope.security.interfaces import IForbidden
 from zExceptions.unauthorized import Unauthorized
 
-
-# __builtins__ was renamed to builtins in Python 3
-try:
-    import __builtin__ as builtins
-except ImportError:
-    import builtins
-
-
-# Python 3 no longer has old-style classes
-CLASS_TYPES = [type]
-try:
-    from types import ClassType
-except ImportError:
-    pass
-else:
-    CLASS_TYPES.append(ClassType)
-CLASS_TYPES = tuple(CLASS_TYPES)
+from ._compat import builtins
+from ._compat import class_types
+from ._compat import string_types
 
 
 @implementer(IException)
@@ -53,12 +39,12 @@ class InternalError(Exception):
     pass
 
 
-@implementer(IException)
+@implementer(INotFound)
 class NotFound(Exception):
     pass
 
 
-@implementer(IException)
+@implementer(IForbidden)
 class Forbidden(Exception):
     pass
 
@@ -79,7 +65,7 @@ def convertExceptionType(name):
     elif hasattr(zExceptions, name):
         etype = getattr(zExceptions, name)
     if (etype is not None and
-        isinstance(etype, CLASS_TYPES) and
+        isinstance(etype, class_types) and
         issubclass(etype, Exception)):
         return etype
 
@@ -89,7 +75,7 @@ def upgradeException(t, v):
     # exception defined either in builtins or zExceptions. If none of
     # that works, then convert it to an InternalError and keep the
     # original exception name as part of the exception value.
-    if isinstance(t, basestring):
+    if isinstance(t, string_types):
         warnings.warn('String exceptions are deprecated starting '
                     'with Python 2.5 and will be removed in a '
                     'future release', DeprecationWarning, stacklevel=2)

--- a/src/zExceptions/__init__.py
+++ b/src/zExceptions/__init__.py
@@ -18,7 +18,7 @@ application-specific packages.
 
 import warnings
 
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface.common.interfaces import IException
 from zope.publisher.interfaces import INotFound
 from zope.security.interfaces import IForbidden
@@ -43,20 +43,24 @@ else:
 CLASS_TYPES = tuple(CLASS_TYPES)
 
 
+@implementer(IException)
 class BadRequest(Exception):
-    implements(IException)
+    pass
 
 
+@implementer(IException)
 class InternalError(Exception):
-    implements(IException)
+    pass
 
 
+@implementer(IException)
 class NotFound(Exception):
-    implements(INotFound)
+    pass
 
 
+@implementer(IException)
 class Forbidden(Exception):
-    implements(IForbidden)
+    pass
 
 
 class MethodNotAllowed(Exception):

--- a/src/zExceptions/__init__.py
+++ b/src/zExceptions/__init__.py
@@ -17,6 +17,7 @@ application-specific packages.
 """
 
 from types import ClassType
+import __builtin__
 import warnings
 
 from zope.interface import implements
@@ -53,8 +54,8 @@ class Redirect(Exception):
 def convertExceptionType(name):
     import zExceptions
     etype = None
-    if name in __builtins__:
-        etype = __builtins__[name]
+    if name in __builtin__.__dict__:
+        etype = getattr(__builtin__, name)
     elif hasattr(zExceptions, name):
         etype = getattr(zExceptions, name)
     if (etype is not None and

--- a/src/zExceptions/__init__.py
+++ b/src/zExceptions/__init__.py
@@ -22,7 +22,7 @@ from zope.interface import implementer
 from zope.interface.common.interfaces import IException
 from zope.publisher.interfaces import INotFound
 from zope.security.interfaces import IForbidden
-from zExceptions.unauthorized import Unauthorized
+from zExceptions.unauthorized import Unauthorized  # noqa
 
 from ._compat import builtins
 from ._compat import class_types
@@ -65,8 +65,8 @@ def convertExceptionType(name):
     elif hasattr(zExceptions, name):
         etype = getattr(zExceptions, name)
     if (etype is not None and
-        isinstance(etype, class_types) and
-        issubclass(etype, Exception)):
+            isinstance(etype, class_types) and
+            issubclass(etype, Exception)):
         return etype
 
 
@@ -76,9 +76,10 @@ def upgradeException(t, v):
     # that works, then convert it to an InternalError and keep the
     # original exception name as part of the exception value.
     if isinstance(t, string_types):
-        warnings.warn('String exceptions are deprecated starting '
-                    'with Python 2.5 and will be removed in a '
-                    'future release', DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            'String exceptions are deprecated starting '
+            'with Python 2.5 and will be removed in a '
+            'future release', DeprecationWarning, stacklevel=2)
 
         etype = convertExceptionType(t)
         if etype is not None:

--- a/src/zExceptions/_compat.py
+++ b/src/zExceptions/_compat.py
@@ -1,3 +1,4 @@
+import codecs
 import sys
 
 
@@ -7,9 +8,13 @@ if PY3:
     class_types = type,
     string_types = (str, bytes)
     unicode = str
+    u = lambda s: s
 else:
     import __builtin__ as builtins  # noqa
     from types import ClassType
     class_types = (type, ClassType)
     string_types = basestring,
     unicode = unicode
+
+    def u(s):
+        return codecs.unicode_escape_decode(s)[0]

--- a/src/zExceptions/_compat.py
+++ b/src/zExceptions/_compat.py
@@ -1,0 +1,15 @@
+import sys
+
+
+PY3 = sys.version_info[0] == 3
+if PY3:
+    import builtins
+    class_types = type,
+    string_types = (str, bytes)
+    unicode = str
+else:
+    import __builtin__ as builtins
+    from types import ClassType
+    class_types = (type, ClassType)
+    string_types = basestring,
+    unicode = unicode

--- a/src/zExceptions/_compat.py
+++ b/src/zExceptions/_compat.py
@@ -8,7 +8,7 @@ if PY3:
     string_types = (str, bytes)
     unicode = str
 else:
-    import __builtin__ as builtins
+    import __builtin__ as builtins  # noqa
     from types import ClassType
     class_types = (type, ClassType)
     string_types = basestring,

--- a/src/zExceptions/tests/testExceptionFormatter.py
+++ b/src/zExceptions/tests/testExceptionFormatter.py
@@ -124,7 +124,7 @@ class Test(TestCase):
         class C:
             pass
         try:
-            raise TypeError, C()
+            raise TypeError(C())
         except:
             s = tb(1)
         else:

--- a/src/zExceptions/tests/test_unauthorized.py
+++ b/src/zExceptions/tests/test_unauthorized.py
@@ -16,8 +16,7 @@
 
 import unittest
 from zope.interface.verify import verifyClass
-
-_MESSAGE = "You are not allowed to access '%s' in this context"
+from .._compat import unicode
 
 
 class UnauthorizedTests(unittest.TestCase):
@@ -43,11 +42,11 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(exc.value, None)
         self.assertEqual(exc.needed, None)
 
-        self.assertEqual(str(exc), str(repr(exc)))
-        self.assertEqual(unicode(exc), unicode(repr(exc)))
+        self.assertEqual(bytes(exc), b'Unauthorized()')
+        self.assertEqual(unicode(exc), u'Unauthorized()')
 
     def test_ascii_message(self):
-        arg = 'ERROR MESSAGE'
+        arg = b'ERROR MESSAGE'
         exc = self._makeOne(arg)
 
         self.assertEqual(exc.name, None)
@@ -55,7 +54,7 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(exc.value, None)
         self.assertEqual(exc.needed, None)
 
-        self.assertEqual(str(exc), arg)
+        self.assertEqual(bytes(exc), arg)
         self.assertEqual(unicode(exc), arg.decode('ascii'))
 
     def test_encoded_message(self):
@@ -67,8 +66,8 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(exc.value, None)
         self.assertEqual(exc.needed, None)
 
-        self.assertEqual(str(exc), arg)
-        self.assertRaises(UnicodeDecodeError, unicode, exc)
+        self.assertEqual(bytes(exc), arg)
+        self.assertEqual(unicode(exc), arg.decode('utf-8'))
 
     def test_unicode_message(self):
         arg = u'ERROR MESSAGE \u03A9'
@@ -79,11 +78,11 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(exc.value, None)
         self.assertEqual(exc.needed, None)
 
-        self.assertRaises(UnicodeEncodeError, str, exc)
+        self.assertEqual(bytes(exc), arg.encode('utf-8'))
         self.assertEqual(unicode(exc), arg)
 
     def test_ascii_name(self):
-        arg = 'ERROR_NAME'
+        arg = b'ERROR_NAME'
         exc = self._makeOne(arg)
 
         self.assertEqual(exc.name, arg)
@@ -91,8 +90,10 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(exc.value, None)
         self.assertEqual(exc.needed, None)
 
-        self.assertEqual(str(exc), _MESSAGE % arg)
-        self.assertEqual(unicode(exc), _MESSAGE % arg.decode('ascii'))
+        self.assertEqual(
+            bytes(exc), b"You are not allowed to access 'ERROR_NAME' in this context")
+        self.assertEqual(
+            unicode(exc), u"You are not allowed to access 'ERROR_NAME' in this context")
 
     def test_encoded_name(self):
         arg = u'ERROR_NAME_\u03A9'.encode('utf-8')
@@ -103,8 +104,10 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(exc.value, None)
         self.assertEqual(exc.needed, None)
 
-        self.assertEqual(str(exc), _MESSAGE % arg)
-        self.assertRaises(UnicodeDecodeError, unicode, exc)
+        self.assertEqual(
+            bytes(exc), b"You are not allowed to access 'ERROR_NAME_\xce\xa9' in this context")
+        self.assertEqual(
+            unicode(exc), u"You are not allowed to access 'ERROR_NAME_\u03A9' in this context")
 
     def test_unicode_name(self):
         arg = u'ERROR_NAME_\u03A9'
@@ -115,8 +118,10 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(exc.value, None)
         self.assertEqual(exc.needed, None)
 
-        self.assertRaises(UnicodeEncodeError, str, exc)
-        self.assertEqual(unicode(exc), _MESSAGE % arg)
+        self.assertEqual(
+            bytes(exc), b"You are not allowed to access 'ERROR_NAME_\xce\xa9' in this context")
+        self.assertEqual(
+            unicode(exc), u"You are not allowed to access 'ERROR_NAME_\u03A9' in this context")
 
 
 def test_suite():

--- a/src/zExceptions/tests/test_unauthorized.py
+++ b/src/zExceptions/tests/test_unauthorized.py
@@ -17,6 +17,7 @@
 import unittest
 from zope.interface.verify import verifyClass
 from .._compat import unicode
+from .._compat import u
 
 
 class UnauthorizedTests(unittest.TestCase):
@@ -43,7 +44,7 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(exc.needed, None)
 
         self.assertEqual(bytes(exc), b'Unauthorized()')
-        self.assertEqual(unicode(exc), u'Unauthorized()')
+        self.assertEqual(unicode(exc), u('Unauthorized()'))
 
     def test_ascii_message(self):
         arg = b'ERROR MESSAGE'
@@ -58,7 +59,7 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(unicode(exc), arg.decode('ascii'))
 
     def test_encoded_message(self):
-        arg = u'ERROR MESSAGE \u03A9'.encode('utf-8')
+        arg = u('ERROR MESSAGE \u03A9').encode('utf-8')
         exc = self._makeOne(arg)
 
         self.assertEqual(exc.name, None)
@@ -70,7 +71,7 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(unicode(exc), arg.decode('utf-8'))
 
     def test_unicode_message(self):
-        arg = u'ERROR MESSAGE \u03A9'
+        arg = u('ERROR MESSAGE \u03A9')
         exc = self._makeOne(arg)
 
         self.assertEqual(exc.name, None)
@@ -93,10 +94,10 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(
             bytes(exc), b"You are not allowed to access 'ERROR_NAME' in this context")
         self.assertEqual(
-            unicode(exc), u"You are not allowed to access 'ERROR_NAME' in this context")
+            unicode(exc), u("You are not allowed to access 'ERROR_NAME' in this context"))
 
     def test_encoded_name(self):
-        arg = u'ERROR_NAME_\u03A9'.encode('utf-8')
+        arg = u('ERROR_NAME_\u03A9').encode('utf-8')
         exc = self._makeOne(arg)
 
         self.assertEqual(exc.name, arg)
@@ -107,10 +108,10 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(
             bytes(exc), b"You are not allowed to access 'ERROR_NAME_\xce\xa9' in this context")
         self.assertEqual(
-            unicode(exc), u"You are not allowed to access 'ERROR_NAME_\u03A9' in this context")
+            unicode(exc), u("You are not allowed to access 'ERROR_NAME_\u03A9' in this context"))
 
     def test_unicode_name(self):
-        arg = u'ERROR_NAME_\u03A9'
+        arg = u('ERROR_NAME_\u03A9')
         exc = self._makeOne(arg)
 
         self.assertEqual(exc.name, arg)
@@ -121,7 +122,7 @@ class UnauthorizedTests(unittest.TestCase):
         self.assertEqual(
             bytes(exc), b"You are not allowed to access 'ERROR_NAME_\xce\xa9' in this context")
         self.assertEqual(
-            unicode(exc), u"You are not allowed to access 'ERROR_NAME_\u03A9' in this context")
+            unicode(exc), u("You are not allowed to access 'ERROR_NAME_\u03A9' in this context"))
 
 
 def test_suite():

--- a/src/zExceptions/unauthorized.py
+++ b/src/zExceptions/unauthorized.py
@@ -43,35 +43,39 @@ class Unauthorized(Exception):
         provides are added to needed.
         """
         if name is None and (
-            not isinstance(message, string_types) or len(message.split()) <= 1):
+                not isinstance(message, string_types) or len(message.split()) <= 1):
             # First arg is a name, not a message
-            name=message
-            message=None
+            name = message
+            message = None
 
-        self.name=name
-        self._message=message
-        self.value=value
+        self.name = name
+        self._message = message
+        self.value = value
 
         if kw:
-            if needed: needed.update(kw)
-            else: needed=kw
+            if needed:
+                needed.update(kw)
+            else:
+                needed = kw
 
-        self.needed=needed
+        self.needed = needed
 
     def __unicode__(self):
         if self.message is not None:
-            message = self.message if isinstance(self.message, unicode) else self.message.decode('utf-8')
+            message = self.message if isinstance(self.message, unicode) else self.message.decode(
+                'utf-8')
             return message
         if self.name is not None:
             name = self.name if isinstance(self.name, unicode) else self.name.decode('utf-8')
             return ("You are not allowed to access '%s' in this context" % name)
         elif self.value is not None:
-            return ("You are not allowed to access '%s' in this context" 
+            return ("You are not allowed to access '%s' in this context"
                     % self.getValueName())
         return repr(self)
 
     if PY3:
         __str__ = __unicode__
+
         def __bytes__(self):
             return self.__unicode__().encode('utf-8')
     else:
@@ -79,9 +83,10 @@ class Unauthorized(Exception):
             return self.__unicode__().encode('utf-8')
 
     def getValueName(self):
-        v=self.value
-        vname=getattr(v, '__name__', None)
-        if vname: return vname
+        v = self.value
+        vname = getattr(v, '__name__', None)
+        if vname:
+            return vname
         c = getattr(v, '__class__', type(v))
         c = getattr(c, '__name__', 'object')
         return "a particular %s" % c

--- a/src/zExceptions/unauthorized.py
+++ b/src/zExceptions/unauthorized.py
@@ -11,14 +11,14 @@
 #
 ##############################################################################
 
-from zope.interface import implements
+from zope.interface import implementer
 from zope.security.interfaces import IUnauthorized
 
 
+@implementer(IUnauthorized)
 class Unauthorized(Exception):
     """Some user wasn't allowed to access a resource
     """
-    implements(IUnauthorized)
 
     def _get_message(self):
         return self._message

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist =
+    py26,py27,py32,py33,py34,pypy,pypy3,coverage
+
+[testenv]
+commands =
+    nosetests --pdb
+deps =
+    nose
+
+[testenv:coverage]
+basepython =
+    python2.7
+commands =
+    nosetests --with-xunit --with-xcoverage --where={envsitepackagesdir}/zExceptions --cover-package=zExceptions
+deps =
+    nose
+    coverage
+    nosexcover

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
 
 [testenv]
 commands =
-    nosetests --pdb
+    nosetests
 deps =
     nose
 


### PR DESCRIPTION
This adds configuration for running tests with tox, and compatibility with PyPy and Python 3.

The biggest change here is to the `__str__` and `__unicode__` methods of the Unauthorized exception. `__str__` used to return either bytes or unicode depending on the exception argument types (because of implicit conversion), and then `__unicode__` would try to decode as ascii if necessary, sometimes resulting in a UnicodeDecodeError (and there were tests for this). Now the canonical implementation is moved to `__unicode__` (aliased to `__str__` on python 3) which decodes the exception arguments as utf-8 if necessary and returns unicode. That value is then encoded by `__str__` on python 2 and `__bytes__` on python 3.