### PR TITLE
add setHeader method to HTTPException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - 3.4
     - 3.5
     - pypy
-    - pypy3
+    - pypy3.3-5.2-alpha1
 install:
     - python bootstrap.py
     - bin/buildout

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Use `str(self)` as detail if it is not set.
 
+- Add a `setHeader` method to add a response header to an HTTPException.
+
 3.4 (2016-09-08)
 ----------------
 

--- a/src/zExceptions/__init__.py
+++ b/src/zExceptions/__init__.py
@@ -160,11 +160,15 @@ class HTTPException(Exception):
             reason = reason
         self.errmsg = reason
 
+    def setHeader(self, name, value):
+        if not hasattr(self, 'headers'):
+            self.headers = {}
+        self.headers[name] = value
+
     def __call__(self, environ, start_response):
-        if self.empty_body:
-            headers = []
-        else:
-            headers = [('content-type', 'text/html;charset=utf-8')]
+        headers = getattr(self, 'headers', {}).items()
+        if not self.empty_body:
+            headers.append(('content-type', 'text/html;charset=utf-8'))
         if self.errmsg is not None:
             reason = self.errmsg
         reason = status_reasons[self.getStatus()]

--- a/src/zExceptions/__init__.py
+++ b/src/zExceptions/__init__.py
@@ -166,7 +166,7 @@ class HTTPException(Exception):
         self.headers[name] = value
 
     def __call__(self, environ, start_response):
-        headers = getattr(self, 'headers', {}).items()
+        headers = list(getattr(self, 'headers', {}).items())
         if not self.empty_body:
             headers.append(('content-type', 'text/html;charset=utf-8'))
         if self.errmsg is not None:


### PR DESCRIPTION
@hannosch This adds a way to add HTTP headers to exception instances, which will be used by the pull request I'm going to open for Zope to change how Unauthorized and Redirect are handled by the WSGIPublisher