### PR TITLE
add support for finding the zException HTTPException class with the same name as an arbitrary exception class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 
 - Add a `setHeader` method to add a response header to an HTTPException.
 
+- `upgradeException` now also supports finding an HTTPException class
+  with the same name as a non-HTTPException class.
+
 3.4 (2016-09-08)
 ----------------
 

--- a/src/zExceptions/__init__.py
+++ b/src/zExceptions/__init__.py
@@ -528,4 +528,8 @@ def upgradeException(t, v):
         else:
             v = t, v
             t = InternalError
+    else:
+        etype = convertExceptionType(t.__name__)
+        if etype is not None:
+            t = etype
     return t, v

--- a/src/zExceptions/tests/test___init__.py
+++ b/src/zExceptions/tests/test___init__.py
@@ -172,3 +172,12 @@ class TestUpgradeException(unittest.TestCase):
         t, v = self._callFUT('Nonesuch', 'TEST')
         self.assertEqual(t, InternalError)
         self.assertEqual(v, ('Nonesuch', 'TEST'))
+
+    def test_non_string_match_by_name(self):
+        class NotFound(Exception):
+            pass
+
+        t, v = self._callFUT(NotFound, 'TEST')
+        from zExceptions import NotFound as zExceptions_NotFound
+        self.assertIs(t, zExceptions_NotFound)
+        self.assertEqual(v, 'TEST')


### PR DESCRIPTION
(see https://github.com/zopefoundation/Zope/pull/95#issuecomment-277243079)