### PR TITLE
Move package metadata from setup.py to pyproject.toml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,8 @@ jobs:
       with:
         persist-credentials: false
     - name: Install uv + caching
-      # astral/setup-uv@7.3.0
-      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b
+      # astral/setup-uv@7.5.0
+      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82
       with:
         enable-cache: true
         cache-dependency-glob: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ lib64
 log/
 parts/
 pyvenv.cfg
+share/
 testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "2253eec2"
+commit-id = "9832deed"
 
 [python]
 with-windows = false
@@ -11,6 +11,7 @@ with-future-python = true
 with-sphinx-doctests = false
 with-macos = false
 with-docs = false
+with-free-threaded-python = false
 
 [tox]
 testenv-skip-test-extra = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     rev: 0.4.3
     hooks:
     - id: teyit
+      language_version: python3.13
   - repo: https://github.com/PyCQA/flake8
     rev: "7.3.0"
     hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 6.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Move package metadata from setup.py to pyproject.toml.
 
 
 6.0 (2026-02-19)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,51 @@
 # Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
-
 [build-system]
 requires = [
     "setuptools >= 78.1.1,< 81",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+
+[project]
+name = "zExceptions"
+version = "6.1.dev0"
+description = "zExceptions contains common exceptions used in Zope."
+license = "ZPL-2.1"
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Environment :: Web Environment",
+    "Framework :: Zope :: 5",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = ["readme"]
+requires-python = ">=3.10"
+authors = [
+    {name = "Zope Foundation and contributors",email = "zope-dev@zope.dev"},
+]
+maintainers = [
+    {name = "Plone Foundation and contributors",email = "zope-dev@zope.dev"},
+]
+dependencies = [
+    "zope.interface",
+    "zope.publisher",
+    "zope.security",
+]
+
+[project.urls]
+Source = "https://github.com/zopefoundation/zExceptions"
+Issues = "https://github.com/zopefoundation/zExceptions/issues"
+Changelog = "https://github.com/zopefoundation/zExceptions/blob/master/CHANGES.rst"
 
 [tool.coverage.run]
 branch = true
@@ -32,3 +69,7 @@ exclude_lines = [
 
 [tool.coverage.html]
 directory = "parts/htmlcov"
+
+[tool.setuptools.dynamic]
+readme = {file = ["README.rst", "CHANGES.rst"]}
+

--- a/setup.py
+++ b/setup.py
@@ -12,52 +12,8 @@
 #
 ##############################################################################
 
-from setuptools import find_packages
 from setuptools import setup
 
 
-setup(
-    name='zExceptions',
-    version='6.1.dev0',
-    url='https://github.com/zopefoundation/zExceptions',
-    license='ZPL-2.1',
-    description="zExceptions contains common exceptions used in Zope.",
-    author='Zope Foundation and Contributors',
-    author_email='zope-dev@zope.dev',
-    project_urls={
-        'Issue Tracker': 'https://github.com/zopefoundation/'
-                         'zExceptions/issues',
-        'Sources': 'https://github.com/zopefoundation/zExceptions',
-    },
-
-    long_description=(open('README.rst').read() + '\n' +
-                      open('CHANGES.rst').read()),
-    long_description_content_type='text/x-rst',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    python_requires='>=3.10',
-    install_requires=[
-        'setuptools',
-        'zope.interface',
-        'zope.publisher',
-        'zope.security',
-    ],
-    classifiers=[
-        "Development Status :: 6 - Mature",
-        "Environment :: Web Environment",
-        "Framework :: Zope :: 5",
-        "License :: OSI Approved :: Zope Public License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-    ],
-    include_package_data=True,
-    zip_safe=False,
-)
+# See pyproject.toml for package metadata
+setup()


### PR DESCRIPTION
Fixes #18 
Replaces #19 

Package management files are updated using zope.meta (see https://zopemeta.readthedocs.io/en/latest/) so I updated them and also removed the setuptools dependency. This replaces #19.

CC: @stanislavlevin
